### PR TITLE
💄 Design: 해커톤 상세 페이지 레이아웃 구현

### DIFF
--- a/src/components/common/button/scrab/index.styles.ts
+++ b/src/components/common/button/scrab/index.styles.ts
@@ -3,6 +3,6 @@ import styled from "@emotion/styled";
 export const StyledScrabButton = styled.button`
   border: none;
   cursor: pointer;
-  padding: 0;
-  margin-left: 1rem;
+  padding: 0.5rem 0 0 0.5rem;
+  margin: 0.5rem 0 0 0.5rem;
 `;

--- a/src/components/hackathons/detail/comment/index.tsx
+++ b/src/components/hackathons/detail/comment/index.tsx
@@ -1,0 +1,5 @@
+const Comment = () => {
+  return <div>댓글</div>;
+};
+
+export default Comment;

--- a/src/components/hackathons/detail/index.tsx
+++ b/src/components/hackathons/detail/index.tsx
@@ -1,5 +1,19 @@
+import Hr from "components/common/hr";
+
+import Comment from "./comment";
+import Original from "./original/indes";
+import Summary from "./summary";
+
 const HackathonDetail = () => {
-  return <div>해커톤 상세</div>;
+  return (
+    <>
+      <Summary />
+      <Hr />
+      <Original />
+      <Hr />
+      <Comment />
+    </>
+  );
 };
 
 export default HackathonDetail;

--- a/src/components/hackathons/detail/original/indes.tsx
+++ b/src/components/hackathons/detail/original/indes.tsx
@@ -1,0 +1,5 @@
+const Original = () => {
+  return <details>해커톤 원문</details>;
+};
+
+export default Original;

--- a/src/components/hackathons/detail/summary/index.styles.ts
+++ b/src/components/hackathons/detail/summary/index.styles.ts
@@ -1,0 +1,130 @@
+import styled from "@emotion/styled";
+import { palette } from "styles/palette";
+
+export const Wrapper = styled.section`
+  padding: 0 2.5rem;
+`;
+
+export const Header = styled.header`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  height: 6rem;
+`;
+
+export const Title = styled.h2`
+  color: ${palette.black};
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 2.625rem;
+`;
+
+export const ScrabViewBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2.5rem;
+
+  font-size: 1.25rem;
+`;
+
+export const ScrabCount = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-weight: 700;
+`;
+
+export const ViewCount = styled.div`
+  color: ${palette.fontGray200};
+  font-weight: 400;
+`;
+
+export const Hr = styled.div`
+  border-top: 1px solid ${palette.bdGray300};
+  margin-bottom: 3.44rem;
+`;
+
+export const Body = styled.main`
+  display: flex;
+  gap: 4.5rem;
+`;
+
+export const ImageBox = styled.div`
+  border-radius: 0.625rem;
+  max-width: 369px;
+  max-height: 522;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  /* FIXME: 추후 삭제 */
+  > img {
+    transform: scale(1.3);
+  }
+`;
+
+export const Information = styled.div`
+  width: 100%;
+  font-size: 1.5rem;
+  font-weight: 700;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const Summary = styled.div`
+  > div {
+    display: flex;
+    gap: 2.25rem;
+    margin-bottom: 3rem;
+  }
+`;
+
+export const CautionAndApply = styled.div``;
+
+export const Label = styled.label`
+  color: #8e8e8e;
+  min-width: 6.75rem;
+`;
+
+export const Content = styled.span`
+  color: ${palette.black};
+`;
+
+export const Organizer = styled.div``;
+export const ReceptionPeriod = styled.div``;
+export const CompetitionField = styled.div``;
+export const Source = styled.div``;
+
+export const Caution = styled.p`
+  color: ${palette.fontRed100};
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.875rem;
+  mark {
+    color: inherit;
+    background-color: transparent;
+    font-weight: 700;
+  }
+
+  margin-bottom: 3rem;
+`;
+
+export const Apply = styled.div``;
+
+export const ApplyButton = styled.button`
+  width: 11.0625rem;
+  height: 2.8125rem;
+  border: 1px solid ${palette.bdMainOrange};
+  color: ${palette.white};
+
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.875rem;
+  border-radius: 1.875rem;
+  background: ${palette.bgMainOrange};
+`;

--- a/src/components/hackathons/detail/summary/index.tsx
+++ b/src/components/hackathons/detail/summary/index.tsx
@@ -1,0 +1,66 @@
+import ScrabButton from "components/common/button/scrab";
+import Image from "next/image";
+
+import * as S from "./index.styles";
+
+const Summary = () => {
+  return (
+    <S.Wrapper>
+      <S.Header>
+        <S.Title>성동구 청년정책 해커톤</S.Title>
+        <S.ScrabViewBox>
+          <S.ScrabCount>
+            <ScrabButton />
+            <span>{152}</span>
+          </S.ScrabCount>
+          <S.ViewCount>조회수 {250}</S.ViewCount>
+        </S.ScrabViewBox>
+      </S.Header>
+      <S.Hr />
+      <S.Body>
+        <S.ImageBox>
+          <Image
+            src="/mocks/hackathon_poster_big.png"
+            width={369}
+            height={522}
+            alt="해커톤 포스터 이미지"
+          />
+        </S.ImageBox>
+        <S.Information>
+          <S.Summary>
+            <S.Organizer>
+              <S.Label>주체 / 기관</S.Label>
+              <S.Content>{"킹십리"}</S.Content>
+            </S.Organizer>
+            <S.ReceptionPeriod>
+              <S.Label>접수 기간</S.Label>
+              <S.Content>
+                {"2023년 07월 12일"} ~ {"2023년 07월 26일 00:00"}
+              </S.Content>
+            </S.ReceptionPeriod>
+            <S.CompetitionField>
+              <S.Label>공모 분야</S.Label>
+              <S.Content>{"해커톤"}</S.Content>
+            </S.CompetitionField>
+            <S.Source>
+              <S.Label>출처</S.Label>
+              <S.Content>{""}</S.Content>
+            </S.Source>
+          </S.Summary>
+          <S.CautionAndApply>
+            <S.Caution>
+              <mark>학습 및 포트폴리오 목적으로 만든 사이트</mark>로{" "}
+              <mark>단순 정보 전달</mark>을<br /> 목적으로 합니다.{" "}
+              <mark>해당 대회 주최 기관과는 무관</mark>합니다.
+            </S.Caution>
+            <S.Apply>
+              <S.ApplyButton>지원하기</S.ApplyButton>
+            </S.Apply>
+          </S.CautionAndApply>
+        </S.Information>
+      </S.Body>
+    </S.Wrapper>
+  );
+};
+
+export default Summary;

--- a/src/pages/hackathons/[id]/index.tsx
+++ b/src/pages/hackathons/[id]/index.tsx
@@ -1,5 +1,7 @@
-const HackathonDetail = () => {
-  return <div>해커톤/공모전 상세 페이지</div>;
+import HackathonDetail from "components/hackathons/detail";
+
+const HackathonDetailPage = () => {
+  return <HackathonDetail />;
 };
 
-export default HackathonDetail;
+export default HackathonDetailPage;


### PR DESCRIPTION
해커톤 상세 페이지 요약, 원문, 댓글로 섹션 생성 후 구분

요약 부분 퍼블리싱

공통 컴포넌트 ScrabButton 아이콘 그림자로 인한 위치 불안정을 padding, margin 조합으로 고정