### PR TITLE
💄 Design: 마이 페이지 레이아웃 구현 및 스타일링

### DIFF
--- a/src/components/common/card/hackathons/HackathonPageCard.tsx
+++ b/src/components/common/card/hackathons/HackathonPageCard.tsx
@@ -106,6 +106,7 @@ const Title = styled.span`
   line-height: 2.25rem;
 `;
 const Organizer = styled.span`
+  font-weight: 400;
   font-size: 1.125rem;
   line-height: 1.6875rem;
 `;
@@ -114,5 +115,7 @@ const Hr = styled.div`
   margin-block: 1.7rem;
 `;
 const AdditionalInfo = styled.span`
+  font-weight: 400;
+  font-size: 1.125rem;
   line-height: 1.5rem;
 `;

--- a/src/components/hackathons/detail/comment/index.tsx
+++ b/src/components/hackathons/detail/comment/index.tsx
@@ -44,18 +44,6 @@ const Comment = () => {
     <section>
       <S.CommentCount>
         <Image width={24} height={24} src={ChatSVG} alt="말풍선" />
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="48"
-          height="48"
-          viewBox="0 0 48 48"
-          fill="none"
-        >
-          <path
-            d="M4 44V7C4 6.2 4.3 5.5 4.9 4.9C5.5 4.3 6.2 4 7 4H41C41.8 4 42.5 4.3 43.1 4.9C43.7 5.5 44 6.2 44 7V33C44 33.8 43.7 34.5 43.1 35.1C42.5 35.7 41.8 36 41 36H12L4 44ZM10.7 33H41V7H7V37L10.7 33Z"
-            fill="black"
-          />
-        </svg>
         <span>모집글 {2}개</span>
       </S.CommentCount>
       <NewComment />

--- a/src/components/userInfo/index.styles.ts
+++ b/src/components/userInfo/index.styles.ts
@@ -1,0 +1,51 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { palette } from "styles/palette";
+
+interface ButtonProps {
+  backgroundColor: string;
+}
+
+export const TextStyle = css`
+  color: #000;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+`;
+
+export const Wrapper = styled.div`
+  > *:nth-of-type(2n-1) {
+    padding-inline: 2rem;
+  }
+  padding-block: 6rem;
+`;
+
+export const H2 = styled.h2`
+  color: ${palette.black};
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 2.625rem;
+`;
+
+export const Label = styled.label`
+  color: ${palette.black};
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+  min-width: fit-content;
+`;
+
+export const Button = styled.button<ButtonProps>`
+  width: 9.6875rem;
+  height: 2.8125rem;
+  border: none;
+  border-radius: 1.875rem;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+
+  /* 내부 text styling */
+  color: #fff;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.875rem;
+`;

--- a/src/components/userInfo/index.tsx
+++ b/src/components/userInfo/index.tsx
@@ -1,5 +1,20 @@
+import Hr from "components/common/hr";
+
+import { Wrapper } from "./index.styles";
+import Profile from "./profile";
+import Scrab from "./scrab";
+import Skills from "./skills";
+
 const UserInfo = () => {
-  return <div>프로필 페이지</div>;
+  return (
+    <Wrapper>
+      <Profile />
+      <Hr />
+      <Skills />
+      <Hr />
+      <Scrab />
+    </Wrapper>
+  );
 };
 
 export default UserInfo;

--- a/src/components/userInfo/profile/index.styles.ts
+++ b/src/components/userInfo/profile/index.styles.ts
@@ -1,0 +1,81 @@
+import styled from "@emotion/styled";
+import { breakPoints } from "styles/breakPoints";
+import { palette } from "styles/palette";
+
+export const ProfileWrapper = styled.section`
+  padding-bottom: 5rem;
+
+  h2 {
+    margin-bottom: 2.75rem;
+  }
+`;
+
+export const ImageController = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 3rem;
+  margin-bottom: 6rem;
+`;
+
+export const ImageBox = styled.div`
+  width: 11.375rem;
+  height: 11.375rem;
+
+  > img {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+export const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+`;
+
+export const NameController = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+
+  @media ${breakPoints.sm} {
+    flex-direction: column;
+  }
+`;
+
+export const Left = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 3rem;
+`;
+
+export const Input = styled.input`
+  width: 22.75rem;
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  border-radius: 0.625rem;
+  border: 1px solid #757575;
+`;
+export const Right = styled.table`
+  tr td:first-of-type {
+    border-right: 3rem solid transparent;
+    border-bottom: 1rem solid transparent;
+  }
+`;
+
+export const Text = styled.span`
+  color: ${palette.fontGray300};
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+`;
+
+export const ProfileController = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 4rem;
+`;

--- a/src/components/userInfo/profile/index.tsx
+++ b/src/components/userInfo/profile/index.tsx
@@ -1,0 +1,72 @@
+import { Button, H2, Label } from "components/userInfo/index.styles";
+import Image from "next/image";
+import { useState } from "react";
+import { palette } from "styles/palette";
+
+import userProfileImageSVG from "/public/mocks/user_profile.svg";
+
+import * as S from "./index.styles";
+
+const Profile = () => {
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const onClickEdit = () => {
+    setIsEdit((prev) => !prev);
+  };
+  return (
+    <S.ProfileWrapper>
+      <H2>차곡 프로필</H2>
+      <S.ImageController>
+        <S.ImageBox>
+          <Image src={userProfileImageSVG} alt="프로필 이미지" />
+        </S.ImageBox>
+        {isEdit && (
+          <S.ButtonBox>
+            <Button backgroundColor={palette.black}>이미지 수정</Button>
+            <Button backgroundColor={palette.black}>이미지 삭제</Button>
+          </S.ButtonBox>
+        )}
+      </S.ImageController>
+      <S.NameController>
+        <S.Left>
+          <Label htmlFor="nickname">닉네임</Label>
+          {!isEdit && <Label>{"테스트 닉네임"}</Label>}
+          {isEdit && (
+            <S.Input id="nickname" type="text" placeholder={"테스트 닉네임"} />
+          )}
+        </S.Left>
+        <S.Right>
+          <tbody>
+            <tr>
+              <td>
+                <Label>소셜 로그인</Label>
+              </td>
+              <td>
+                <S.Text>{"Google"}</S.Text>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Label>이메일</Label>
+              </td>
+              <td>
+                <S.Text>{"test@gmail.com"}</S.Text>
+              </td>
+            </tr>
+          </tbody>
+        </S.Right>
+      </S.NameController>
+      <S.ProfileController>
+        <Button backgroundColor={palette.black} onClick={onClickEdit}>
+          수정하기
+        </Button>
+        {isEdit && (
+          <Button backgroundColor={palette.black} onClick={onClickEdit}>
+            취소하기
+          </Button>
+        )}
+      </S.ProfileController>
+    </S.ProfileWrapper>
+  );
+};
+
+export default Profile;

--- a/src/components/userInfo/scrab/index.styles.ts
+++ b/src/components/userInfo/scrab/index.styles.ts
@@ -1,0 +1,56 @@
+import styled from "@emotion/styled";
+import { palette } from "styles/palette";
+
+export const ScrabWrapper = styled.section`
+  color: ${palette.fontGray300};
+  padding-top: 5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+
+  h2 {
+    margin-bottom: 2.5rem;
+  }
+`;
+
+export const Navigation = styled.nav`
+  ul {
+    display: flex;
+    flex-direction: row;
+    gap: 1.5rem;
+  }
+
+  input:checked + label {
+    color: ${palette.black};
+  }
+
+  label:hover {
+    cursor: pointer;
+  }
+
+  li {
+    position: relative;
+  }
+
+  margin-bottom: 3.5rem;
+`;
+
+export const Input = styled.input`
+  appearance: none;
+  position: absolute;
+`;
+
+export const ScrabList = styled.ul`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  row-gap: 1rem;
+`;
+
+export const ProjectStudyWrapper = styled.div`
+  max-width: 23.75rem;
+  border-radius: 0.625rem;
+  box-shadow: 0px 1px 50px 0px rgba(0, 0, 0, 0.1);
+  padding: 2.3rem;
+`;

--- a/src/components/userInfo/scrab/index.tsx
+++ b/src/components/userInfo/scrab/index.tsx
@@ -1,0 +1,67 @@
+import HackathonPageCard from "components/common/card/hackathons/HackathonPageCard";
+import ProjectCard from "components/common/card/projects";
+import { H2 } from "components/userInfo/index.styles";
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+
+import * as S from "./index.styles";
+
+type TNavItem = "hackathon" | "study" | "project";
+
+const Scrab = () => {
+  const [navItem, setNavItem] = useState<TNavItem>("hackathon");
+
+  const onClickNavItem = (e: ChangeEvent<HTMLInputElement>) => {
+    setNavItem(e.target.id as TNavItem);
+  };
+  return (
+    <S.ScrabWrapper>
+      <H2>내 스크랩</H2>
+      <S.Navigation>
+        <ul>
+          <li>
+            <S.Input
+              id="hackathon"
+              type="radio"
+              name="scrab"
+              onChange={onClickNavItem}
+              defaultChecked
+            />
+            <label htmlFor="hackathon">해커톤</label>
+          </li>
+          <li>
+            <S.Input
+              id="study"
+              type="radio"
+              name="scrab"
+              onChange={onClickNavItem}
+            />
+            <label htmlFor="study">스터디</label>
+          </li>
+          <li>
+            <S.Input
+              id="project"
+              type="radio"
+              name="scrab"
+              onChange={onClickNavItem}
+            />
+            <label htmlFor="project">프로젝트</label>
+          </li>
+        </ul>
+      </S.Navigation>
+      <S.ScrabList>
+        {new Array(6).fill(1).map((_, i) => {
+          if (navItem === "hackathon") return <HackathonPageCard key={i} />;
+          if (navItem === "project" || navItem === "study")
+            return (
+              <S.ProjectStudyWrapper key={i}>
+                <ProjectCard />
+              </S.ProjectStudyWrapper>
+            );
+        })}
+      </S.ScrabList>
+    </S.ScrabWrapper>
+  );
+};
+
+export default Scrab;

--- a/src/components/userInfo/skills/index.styles.ts
+++ b/src/components/userInfo/skills/index.styles.ts
@@ -1,0 +1,81 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { palette } from "styles/palette";
+
+interface ISelectBoxStyle {
+  isEdit: boolean;
+}
+
+export const SkillsWrapper = styled.section`
+  padding-block: 7.4rem 9.5rem;
+  h2 {
+    margin-bottom: 2.5rem;
+  }
+`;
+
+export const SelectBox = styled.form<ISelectBoxStyle>`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  margin-bottom: 5rem;
+
+  ${({ isEdit }) =>
+    isEdit &&
+    css`
+      > * {
+        cursor: pointer;
+      }
+    `}
+`;
+
+export const OptionWrapper = styled.label`
+  position: relative;
+
+  img {
+    position: absolute;
+    left: 1.8rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  ::after {
+    content: attr(data-name);
+    display: block;
+    position: absolute;
+    left: 1.8rem;
+    top: 50%;
+    text-align: center;
+    padding-left: 2rem;
+    transform: translateY(-55%);
+  }
+`;
+
+export const Option = styled.input`
+  appearance: none;
+  width: 11.08125rem;
+  height: 3.5rem;
+  border-radius: 1.875rem;
+  border: 1px solid ${palette.bdGray200};
+
+  :disabled {
+    background-color: ${palette.bgGray300};
+    border: none;
+    cursor: default;
+  }
+
+  :checked {
+    border: 3px solid ${palette.black};
+  }
+
+  cursor: pointer;
+`;
+
+export const SkillController = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 4rem;
+`;

--- a/src/components/userInfo/skills/index.tsx
+++ b/src/components/userInfo/skills/index.tsx
@@ -1,0 +1,49 @@
+import { Button, H2 } from "components/userInfo/index.styles";
+import { SKILLS } from "lib/constants/skills";
+import Image from "next/image";
+import type { ChangeEvent } from "react";
+import { useState } from "react";
+import { palette } from "styles/palette";
+
+import * as S from "./index.styles";
+
+const Skills = () => {
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const onClickEdit = () => {
+    setIsEdit((prev) => !prev);
+  };
+
+  const onClickSkill = (e: ChangeEvent<HTMLInputElement>) => {
+    process.env.NODE_ENV === "development" && console.log(e.target.id);
+  };
+  return (
+    <S.SkillsWrapper>
+      <H2>나의 관심 스택</H2>
+      <S.SelectBox isEdit={isEdit}>
+        {SKILLS.map((el) => (
+          <S.OptionWrapper key={el.id} data-name={el.skill} htmlFor={el.id}>
+            <Image width={24} height={24} src={el.img} alt={el.skill} />
+            <S.Option
+              id={el.id}
+              disabled={!isEdit}
+              type="checkbox"
+              onChange={onClickSkill}
+            />
+          </S.OptionWrapper>
+        ))}
+      </S.SelectBox>
+      <S.SkillController>
+        <Button backgroundColor={palette.black} onClick={onClickEdit}>
+          수정하기
+        </Button>
+        {isEdit && (
+          <Button backgroundColor={palette.black} onClick={onClickEdit}>
+            취소하기
+          </Button>
+        )}
+      </S.SkillController>
+    </S.SkillsWrapper>
+  );
+};
+
+export default Skills;

--- a/src/lib/constants/skills.ts
+++ b/src/lib/constants/skills.ts
@@ -1,3 +1,5 @@
+import type { StaticImageData } from "next/image";
+
 import php from "/public/skills/akar-icons_php-fill.svg";
 import unity from "/public/skills/bxl_unity.svg";
 import c from "/public/skills/devicon_c.svg";
@@ -40,10 +42,10 @@ import docker from "/public/skills/vscode-icons_file-type-docker2.svg";
 export type TSkills = {
   id: string;
   skill: string;
-  img: SVGGraphicsElement;
+  img: StaticImageData;
 };
 
-export const SKILLS = [
+export const SKILLS: TSkills[] = [
   { id: "js", skill: "JavaScript", img: js },
   { id: "ts", skill: "TypeScript", img: ts },
   { id: "react", skill: "React", img: react },

--- a/src/pages/hackathons/index.tsx
+++ b/src/pages/hackathons/index.tsx
@@ -3,6 +3,7 @@ import List from "components/hackathons/list";
 import Recommendation from "components/hackathons/recommendation";
 import { AxiosClient } from "lib/apis/axiosClient";
 import type { IContests } from "lib/types/hackathon";
+import type { NextPage } from "next";
 
 export const getServerSideProps = async () => {
   const { data } = await AxiosClient.get("https://api.chagok.site/hackathons");
@@ -14,7 +15,11 @@ export const getServerSideProps = async () => {
   };
 };
 
-const HackathonPage = ({ contests }: { contests: IContests }) => {
+const HackathonPage: NextPage<{ contests: IContests }> = ({
+  contests,
+}: {
+  contests: IContests;
+}) => {
   // FIXME: 삭제 예정
   if (process.env.NODE_ENV === "development") console.log(contests);
   return (

--- a/src/styles/breakPoints.ts
+++ b/src/styles/breakPoints.ts
@@ -1,4 +1,12 @@
-export const breakPoints = {
+interface IBreakPoints {
+  xs: "(max-width: 480px)";
+  sm: "(max-width: 768px)";
+  md: "(max-width: 1024px)";
+  lg: "(max-width: 1200px)";
+  lx: "(max-width: 1440px)";
+}
+
+export const breakPoints: IBreakPoints = {
   xs: "(max-width: 480px)",
   sm: "(max-width: 768px)",
   md: "(max-width: 1024px)",

--- a/src/styles/palette.ts
+++ b/src/styles/palette.ts
@@ -1,4 +1,35 @@
-export const palette = {
+interface IPalette {
+  black: "#000";
+  white: "#FFF";
+  bgWhite: "#F8F8F8";
+  bgRed: "#FF3D00";
+  bgBlue: "#0090F9";
+  bgGray300: "#EBEBEB";
+  bgGray200: "#AAAAAA";
+  bgGray100: "#757575";
+  bgMainOrange: "#FF6B00";
+  bgSubOrange: "#FFDEC3";
+  bdMainOrange: "#FF6B00";
+  bdGray400: "#F2F2F2";
+  bdGray300: "#B5B5B5";
+  bdGray200: "#757575";
+  bdGray100: "#525252";
+  bdRed100: "#FF3D00";
+  bdBlue100: "#338CF6";
+  fontMainOrange: "#FF6B00";
+  fontGray400: "#888888";
+  fontGray300: "#757575";
+  fontGray200: "#6F6F6F";
+  fontGray100: "#525252";
+  fontBlue100: "#338CF6";
+  fontRed200: "#FF3D00";
+  fontRed100: "#FF3636";
+  hola: "#FFCD00";
+  inflearn: "#00C471";
+  okky: "#0090F9";
+}
+
+export const palette: IPalette = {
   black: "#000",
   white: "#FFF",
   bgWhite: "#F8F8F8",


### PR DESCRIPTION
마이 페이지 유저 프로필, 기술 스택, 스크랩 각각 3 개 섹션으로 나누어 레이아웃 구현

해커톤 카드 디자인 가이드에 따라 스타일 변경

palette, breakPoints, skills 타입 작성

skills svg 기존 타입`SvgGraphicsElement`이 next/image에 맞지 않아서 `StaticImageData` 타입으로 변경