### PR TITLE
:lipstick: Design: Header 패딩 축소

### DIFF
--- a/src/components/common/layout/body/Body.styles.ts
+++ b/src/components/common/layout/body/Body.styles.ts
@@ -6,6 +6,6 @@ export const Main = styled.main`
   min-height: 90vh;
   box-sizing: border-box;
 
-  padding-top: 7.5rem;
+  padding-top: 5.125rem;
   margin: 0 auto;
 `;

--- a/src/components/common/layout/header/index.styles.ts
+++ b/src/components/common/layout/header/index.styles.ts
@@ -18,7 +18,7 @@ export const HeaderInnerWrapper = styled.div`
 
   width: 100%;
   max-width: 1280px;
-  padding: 2.175rem 2.5rem;
+  padding: 1rem 2.5rem;
   margin: 0 auto;
 
   font-size: 1rem;


### PR DESCRIPTION
모바일에서 브라우저 주소창 생성 시 화면이 밑으로 밀려서 슬라이드가 화면을 가득 채우는 문제 발생