### PR TITLE
✨ Feat: 해커톤 목록 페이지 api 연동

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    domains: ["contestkorea.com"],
     dangerouslyAllowSVG: true,
     contentDispositionType: "attachment",
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",

--- a/src/components/common/arrow/index.tsx
+++ b/src/components/common/arrow/index.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 
 interface IArrowProps {
   width: number;
-
   color: string;
 }
 

--- a/src/components/common/card/hackathons/HackathonPageCard.tsx
+++ b/src/components/common/card/hackathons/HackathonPageCard.tsx
@@ -1,43 +1,44 @@
 import styled from "@emotion/styled";
 import ScrabButton from "components/common/button/scrab";
+import type { TContest } from "lib/types/contest";
+import { caculateDDay } from "lib/utils/caculateDDay";
 import Image from "next/image";
 import Link from "next/link";
-import type { MouseEvent } from "react";
+import type { FC, MouseEvent } from "react";
 
-const DummyHackathonItemData = {
-  title: "성동구 청년정책 해커톤",
-  organizer: "킹십리",
-  commentCount: 5,
-  scrabCount: 120,
-  viewCount: 55,
-};
+interface IHackathonPageCardProps {
+  content: TContest | undefined;
+}
 
-const HackathonPageCard = () => {
-  const { title, organizer, commentCount, scrabCount, viewCount } =
-    DummyHackathonItemData;
-
+const HackathonPageCard: FC<IHackathonPageCardProps> = ({ content }) => {
   const onClickScrabButton = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
   };
+
+  if (!content) return <></>;
+
   return (
-    <StyledWrapper href="/hackathons/1">
-      <Image
-        width={380}
-        height={500}
-        src="/mocks/hackathon_poster_big.png"
-        alt="해커톤 포스터 이미지"
-      />
+    <StyledWrapper href={`hackathons/${content.id}`}>
+      <ImageBox background={content.imageUrl}>
+        {content.imageUrl ? (
+          <Image
+            width={380}
+            height={500}
+            src={content.imageUrl}
+            alt="해커톤 포스터 이미지"
+          />
+        ) : (
+          <span>포스터 이미지가 없습니다.</span>
+        )}
+      </ImageBox>
       <ScrabButton onClick={onClickScrabButton} />
       <Description>
         <MainInfoBox>
-          <DDay>D - 15</DDay>
-          <Title>{title}</Title>
-          <Organizer>주최 / 주관 : {organizer}</Organizer>
+          <DDay>{caculateDDay(content.endDate)}</DDay>
+          <Title>{content.title}</Title>
         </MainInfoBox>
         <Hr />
-        <AdditionalInfo>
-          모집글 {commentCount} 스크랩 {scrabCount} 조회수 {viewCount}
-        </AdditionalInfo>
+        <Organizer>주최 / 주관 : {content.host}</Organizer>
       </Description>
     </StyledWrapper>
   );
@@ -53,11 +54,6 @@ const StyledWrapper = styled(Link)`
   max-width: 380px;
   width: 100%;
 
-  /* FIXME: 추후 삭제 */
-  img {
-    transform: scaleX(1.275) scaleY(1.25);
-  }
-
   button {
     z-index: 2;
     position: absolute;
@@ -70,6 +66,24 @@ const StyledWrapper = styled(Link)`
       opacity: 1;
       transform: translateY(0px);
     }
+  }
+`;
+
+const ImageBox = styled.div<{ background: string }>`
+  width: 100%;
+  height: 100%;
+  background: url(${({ background }) => background});
+  background-size: cover;
+  img {
+    object-fit: contain;
+    object-position: center;
+    backdrop-filter: blur(10px);
+  }
+  span {
+    display: block;
+    text-align: center;
+    width: 380px;
+    height: 500px;
   }
 `;
 
@@ -102,8 +116,9 @@ const DDay = styled.span`
   line-height: 2.625rem;
 `;
 const Title = styled.span`
-  font-size: 1.5rem;
-  line-height: 2.25rem;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: 1.6875rem;
 `;
 const Organizer = styled.span`
   font-weight: 400;
@@ -113,9 +128,4 @@ const Organizer = styled.span`
 const Hr = styled.div`
   border-top: 1px solid #fff;
   margin-block: 1.7rem;
-`;
-const AdditionalInfo = styled.span`
-  font-weight: 400;
-  font-size: 1.125rem;
-  line-height: 1.5rem;
 `;

--- a/src/components/common/skillContainer/index.styles.ts
+++ b/src/components/common/skillContainer/index.styles.ts
@@ -10,12 +10,12 @@ interface ISelectBoxStyle {
 export const SelectBox = styled.div<ISelectBoxStyle>`
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 1rem;
   max-height: calc(100vh / 3);
   margin-bottom: 5rem;
-  overflow: scroll;
+  overflow-y: scroll;
   ${({ isEdit }) =>
     isEdit &&
     css`

--- a/src/components/hackathons/list/HackathonList.tsx
+++ b/src/components/hackathons/list/HackathonList.tsx
@@ -1,0 +1,79 @@
+import styled from "@emotion/styled";
+import PaginationButtons from "components/common/button/pagination";
+import HackathonPageCard from "components/common/card/hackathons/HackathonPageCard";
+import { useContestsQuery } from "lib/hooks/useContestsQuery";
+import {
+  getNumberNextBtnClicked,
+  getNumberPrevBtnClicked,
+} from "lib/utils/pagination";
+import type { FC } from "react";
+import { useState } from "react";
+
+import type { TFilter } from ".";
+
+interface IHackathonListSectionProps {
+  filter: TFilter;
+}
+
+const HackathonListSection: FC<IHackathonListSectionProps> = ({ filter }) => {
+  const { sort, direction } = filter;
+  const [pageNumber, setPageNumber] = useState<number>(1);
+  const { data } = useContestsQuery(pageNumber - 1, 12, sort, direction);
+  const handleClickNextArrow = () => {
+    setPageNumber(
+      getNumberNextBtnClicked(pageNumber, Number(data?.totalPages)),
+    );
+  };
+  const handleClickNextDblArrow = () => {
+    setPageNumber(Number(data?.totalPages));
+  };
+  const handleClickPageNumber = (targetPage: number) => {
+    setPageNumber(targetPage);
+  };
+  const handleClickPrevArrow = () => {
+    setPageNumber(getNumberPrevBtnClicked(pageNumber));
+  };
+  const handleClickPrevDblArrow = () => {
+    setPageNumber(1);
+  };
+
+  if (!data) return <></>;
+  return (
+    <>
+      <ListBox>
+        {data.content.map((content) => (
+          <HackathonPageCard key={content.id} content={content} />
+        ))}
+      </ListBox>
+      <PaginationBox>
+        <PaginationButtons
+          handleClickNextArrow={handleClickNextArrow}
+          handleClickNextDblArrow={handleClickNextDblArrow}
+          handleClickPageNumber={handleClickPageNumber}
+          handleClickPrevArrow={handleClickPrevArrow}
+          handleClickPrevDblArrow={handleClickPrevDblArrow}
+          currentPage={pageNumber}
+          totalPages={data.totalPages}
+        />
+      </PaginationBox>
+    </>
+  );
+};
+
+export default HackathonListSection;
+
+const ListBox = styled.div`
+  display: grid;
+  /* FIXME: 반응형 적용 필요 */
+  grid-template-columns: repeat(auto-fill, 23.75rem);
+  grid-gap: 1.87rem;
+
+  margin: 0 auto;
+`;
+const PaginationBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  margin-top: 5rem;
+`;

--- a/src/components/hackathons/list/index.styles.ts
+++ b/src/components/hackathons/list/index.styles.ts
@@ -1,0 +1,51 @@
+import styled from "@emotion/styled";
+
+export const SelectBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  position: relative;
+
+  ::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-left: 1.5px solid black;
+    border-bottom: 1.5px solid black;
+    transform: rotate(-45deg);
+    background-color: white;
+  }
+
+  margin-bottom: 4.5rem;
+`;
+
+export const Select = styled.select`
+  width: 18.6875rem;
+  padding: 0.8rem 2rem;
+  border-radius: 0.625rem;
+  border: 1px solid #525252;
+  font-size: 1.25rem;
+  color: #888;
+  appearance: none;
+`;
+
+export const ListBox = styled.div`
+  display: grid;
+  /* FIXME: 반응형 적용 필요 */
+  grid-template-columns: repeat(auto-fill, 23.75rem);
+  grid-gap: 1.87rem;
+
+  margin: 0 auto;
+`;
+
+export const BottomContents = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  margin-top: 5rem;
+`;

--- a/src/components/hackathons/list/index.tsx
+++ b/src/components/hackathons/list/index.tsx
@@ -1,29 +1,61 @@
-import styled from "@emotion/styled";
 import TopScrollBtn from "components/common/button/topScroll";
-import HackathonPageCard from "components/common/card/hackathons/HackathonPageCard";
+import Loading from "components/common/loading";
 import { H2, H3, Section } from "components/hackathons/index.styles";
+import type { ChangeEvent } from "react";
+import { Suspense, useState } from "react";
+
+import HackathonListSection from "./HackathonList";
+import * as S from "./index.styles";
+
+export type TFilter = {
+  sort:
+    | "hotCount"
+    | "id"
+    | "endDate"
+    | "startDate"
+    | "scrapCount"
+    | "viewCount"
+    | "commentCount";
+  direction: "desc" | "asc";
+};
 
 const List = () => {
+  const [filter, setFilter] = useState<TFilter>({
+    sort: "id",
+    direction: "desc",
+  });
+  const onChangeOption = (e: ChangeEvent<HTMLSelectElement>) => {
+    switch (e.target.value) {
+      case "deadline": // 마감순
+        setFilter({ sort: "endDate", direction: "asc" });
+        break;
+      case "hot": // 인기순
+        setFilter({ sort: "hotCount", direction: "desc" });
+        break;
+      case "comment": // 댓글많은순
+        setFilter({ sort: "commentCount", direction: "desc" });
+        break;
+      default: // 기본값 최신순
+        setFilter({ sort: "id", direction: "desc" });
+        break;
+    }
+  };
   return (
     <>
       <Section>
         <H2>해커톤을 위한 팀원을 모집해보세요</H2>
         <H3>해커톤의 소식을 빠르게 알아보세요!</H3>
-        <SelectBox>
-          <Select>
-            <option>최신순</option>
-            <option>조회순</option>
-            <option>스크랩순</option>
-          </Select>
-        </SelectBox>
-        <ListBox>
-          {new Array(9).fill(1).map((_, i) => (
-            <HackathonPageCard key={i} />
-          ))}
-        </ListBox>
-        <BottomContents>
-          <div>Pagination</div>
-        </BottomContents>
+        <S.SelectBox>
+          <S.Select onChange={onChangeOption}>
+            <option value="latest">최신순</option>
+            <option value="deadline">마감순</option>
+            <option value="hot">인기순</option>
+            <option value="comment">댓글많은순</option>
+          </S.Select>
+        </S.SelectBox>
+        <Suspense fallback={<Loading />}>
+          <HackathonListSection filter={filter} />
+        </Suspense>
       </Section>
       <TopScrollBtn />
     </>
@@ -31,53 +63,3 @@ const List = () => {
 };
 
 export default List;
-
-const SelectBox = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: end;
-  position: relative;
-
-  ::after {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-left: 1.5px solid black;
-    border-bottom: 1.5px solid black;
-    transform: rotate(-45deg);
-    background-color: white;
-  }
-
-  margin-bottom: 4.5rem;
-`;
-
-const Select = styled.select`
-  width: 18.6875rem;
-  padding: 0.8rem 2rem;
-  border-radius: 0.625rem;
-  border: 1px solid #525252;
-  font-size: 1.25rem;
-  color: #888;
-  appearance: none;
-`;
-
-const ListBox = styled.div`
-  display: grid;
-  /* FIXME: 반응형 적용 필요 */
-  grid-template-columns: repeat(auto-fill, 23.75rem);
-  grid-gap: 1.87rem;
-
-  margin: 0 auto;
-`;
-
-const BottomContents = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-
-  margin-top: 5rem;
-`;

--- a/src/components/hackathons/recommendation/HackathonRecommendList.tsx
+++ b/src/components/hackathons/recommendation/HackathonRecommendList.tsx
@@ -1,0 +1,66 @@
+import styled from "@emotion/styled";
+import HackathonPageCard from "components/common/card/hackathons/HackathonPageCard";
+import { useContestsQuery } from "lib/hooks/useContestsQuery";
+import { Pagination } from "swiper";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+const HackathonRecommendList = () => {
+  const { data } = useContestsQuery(0, 9, "hotCount", "desc");
+  return (
+    <CardWrapper
+      slidesPerView={3}
+      spaceBetween={10}
+      modules={[Pagination]}
+      pagination={{ clickable: true }}
+    >
+      {data?.content.map((content) => (
+        <SwiperSlide key={content.id}>
+          <HackathonPageCard content={content} />
+        </SwiperSlide>
+      ))}
+    </CardWrapper>
+  );
+};
+
+export default HackathonRecommendList;
+
+const CardWrapper = styled(Swiper)`
+  margin-block: 2.5rem;
+
+  .swiper-wrapper {
+    padding-bottom: 4rem;
+  }
+
+  .swiper-pagination {
+    > * {
+      transition: all 0.2s ease-in-out;
+    }
+  }
+
+  .swiper-pagination-bullet {
+    position: relative;
+    width: 1.875rem;
+
+    background-color: transparent;
+
+    ::after {
+      content: "";
+      display: block;
+      width: 0.625rem;
+      height: 0.625rem;
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: #888;
+      border-radius: 1.875rem;
+      transition: all 0.3s ease-in-out;
+    }
+  }
+
+  .swiper-pagination-bullet-active {
+    ::after {
+      width: 1.875rem;
+      background-color: #000;
+    }
+  }
+`;

--- a/src/components/hackathons/recommendation/index.tsx
+++ b/src/components/hackathons/recommendation/index.tsx
@@ -1,73 +1,22 @@
 import "swiper/css";
 import "swiper/css/pagination";
 
-import styled from "@emotion/styled";
-import HackathonPageCard from "components/common/card/hackathons/HackathonPageCard";
+import Loading from "components/common/loading";
 import { H2, H3, Section } from "components/hackathons/index.styles";
-// import { palette } from "styles/palette";
-import { Pagination } from "swiper";
-import { Swiper, SwiperSlide } from "swiper/react";
+import { Suspense } from "react";
+
+import HackathonRecommendList from "./HackathonRecommendList";
 
 const Recommendation = () => {
   return (
     <Section>
       <H2>차곡&apos;s 추천</H2>
       <H3>차곡이 추천하는 대회를 살펴보세요!</H3>
-      <CardWrapper
-        slidesPerView={3}
-        spaceBetween={10}
-        modules={[Pagination]}
-        pagination={{ clickable: true }}
-      >
-        {new Array(9).fill(1).map((_, i) => (
-          <SwiperSlide key={i}>
-            <HackathonPageCard />
-          </SwiperSlide>
-        ))}
-      </CardWrapper>
+      <Suspense fallback={<Loading />}>
+        <HackathonRecommendList />
+      </Suspense>
     </Section>
   );
 };
 
 export default Recommendation;
-
-const CardWrapper = styled(Swiper)`
-  margin-block: 2.5rem;
-
-  .swiper-wrapper {
-    padding-bottom: 4rem;
-  }
-
-  .swiper-pagination {
-    > * {
-      transition: all 0.2s ease-in-out;
-    }
-  }
-
-  .swiper-pagination-bullet {
-    position: relative;
-    width: 1.875rem;
-
-    background-color: transparent;
-
-    ::after {
-      content: "";
-      display: block;
-      width: 0.625rem;
-      height: 0.625rem;
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      background-color: #888;
-      border-radius: 1.875rem;
-      transition: all 0.3s ease-in-out;
-    }
-  }
-
-  .swiper-pagination-bullet-active {
-    ::after {
-      width: 1.875rem;
-      background-color: #000;
-    }
-  }
-`;

--- a/src/components/userInfo/scrab/index.tsx
+++ b/src/components/userInfo/scrab/index.tsx
@@ -65,7 +65,8 @@ const Scrab = () => {
       </S.Navigation>
       <S.ScrabList>
         {new Array(6).fill(1).map((_, i) => {
-          if (navItem === "hackathon") return <HackathonPageCard key={i} />;
+          if (navItem === "hackathon")
+            return <HackathonPageCard key={i} content={undefined} />;
           if (navItem === "project" || navItem === "study")
             return (
               <S.ProjectStudyWrapper key={i}>

--- a/src/lib/apis/contests.ts
+++ b/src/lib/apis/contests.ts
@@ -1,0 +1,26 @@
+import type { TContests } from "lib/types/contest";
+
+import { AxiosClient } from "./axiosClient";
+
+export const getContests = async (
+  page: number,
+  size: number,
+  sort:
+    | "hotCount"
+    | "id"
+    | "endDate"
+    | "startDate"
+    | "scrapCount"
+    | "viewCount"
+    | "commentCount",
+  direction: "desc" | "asc",
+): Promise<TContests> => {
+  try {
+    const response = await AxiosClient(
+      `contests?page=${page}&size=${size}&sort=${sort}&direction=${direction}`,
+    );
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/lib/hooks/useContestsQuery/index.tsx
+++ b/src/lib/hooks/useContestsQuery/index.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { getContests } from "lib/apis/contests";
+
+export const useContestsQuery = (
+  page: number,
+  size: number,
+  sort:
+    | "hotCount"
+    | "id"
+    | "endDate"
+    | "startDate"
+    | "scrapCount"
+    | "viewCount"
+    | "commentCount",
+  direction: "desc" | "asc",
+) => {
+  const queryKey = ["contests", page, size, sort, direction];
+
+  const { data } = useQuery(
+    queryKey,
+    () => getContests(page, size, sort, direction),
+    { suspense: true },
+  );
+
+  return { data };
+};

--- a/src/lib/mocks/handler.ts
+++ b/src/lib/mocks/handler.ts
@@ -1,11 +1,1 @@
-import { rest } from "msw";
-
-import contests from "./data/contests.json";
-
-export const handlers = [
-  rest.get("https://api.chagok.site/hackathons", (req, res, ctx) => {
-    // const { size, page, sort, direction } = req.params;
-
-    return res(ctx.json(contests));
-  }),
-];
+export const handlers = [];

--- a/src/lib/types/contest.ts
+++ b/src/lib/types/contest.ts
@@ -1,25 +1,16 @@
-export interface IContest {
+export type TContest = {
+  commentCount: number;
+  id: number;
   endDate: string;
   host: string;
   imageUrl: string;
-  originalUrl: string;
   scrapCount: number;
   startDate: string;
   title: string;
-  viewCount: number;
-}
+};
 
-export interface IContests {
-  content: Array<{
-    commentCount: number;
-    contestId: number;
-    endDate: string;
-    host: string;
-    imageUrl: string;
-    scrapCount: number;
-    startDate: string;
-    title: string;
-  }>;
+export type TContests = {
+  content: TContest[];
   empty: true;
   first: true;
   last: true;
@@ -45,4 +36,28 @@ export interface IContests {
   };
   totalElements: number;
   totalPages: number;
-}
+};
+
+export type TContestDetail = {
+  content: string;
+  endDate: string;
+  host: string;
+  id: number;
+  imageUrl: string;
+  originalUrl: string;
+  scrapCount: number;
+  startDate: string;
+  title: string;
+  viewCount: number;
+};
+
+export type TComment = {
+  commentId: number;
+  content: string;
+  createdDate: string;
+  deleted: boolean;
+  kakaoRef: string;
+  linkedComment: TComment[];
+  memberNickName: string;
+  parentId: number;
+};

--- a/src/lib/utils/caculateDDay/index.ts
+++ b/src/lib/utils/caculateDDay/index.ts
@@ -1,0 +1,19 @@
+export const caculateDDay = (targetDay: string): string => {
+  const now = new Date();
+  const targetDate = new Date(targetDay);
+
+  now.setHours(0, 0, 0, 0);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const timeDiff = targetDate.getTime() - now.getTime();
+
+  if (timeDiff > 0) {
+    const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
+    return `D - ${days}`;
+  } else if (timeDiff === 0) {
+    return "D - day";
+  } else {
+    const days = Math.floor(Math.abs(timeDiff) / (1000 * 60 * 60 * 24));
+    return `D + ${days}`;
+  }
+};

--- a/src/pages/hackathons/index.tsx
+++ b/src/pages/hackathons/index.tsx
@@ -1,27 +1,29 @@
+import { dehydrate, QueryClient } from "@tanstack/react-query";
 import Hr from "components/common/hr";
 import List from "components/hackathons/list";
 import Recommendation from "components/hackathons/recommendation";
-import { AxiosClient } from "lib/apis/axiosClient";
-import type { IContests } from "lib/types/hackathon";
-import type { NextPage } from "next";
+import { getContests } from "lib/apis/contests";
+import type { GetServerSideProps, NextPage } from "next";
 
-export const getServerSideProps = async () => {
-  const { data } = await AxiosClient.get("https://api.chagok.site/hackathons");
-  const contests = { ...data };
+export const getServerSideProps: GetServerSideProps = async () => {
+  const queryClient = new QueryClient();
+  // 차곡 추천(인기순)
+  await queryClient.prefetchQuery(["contests", 0, 9, "hotCount", "desc"], () =>
+    getContests(0, 9, "hotCount", "desc"),
+  );
+  // 초기 리스트
+  await queryClient.prefetchQuery(["contests", 0, 12, "id", "desc"], () =>
+    getContests(0, 12, "id", "desc"),
+  );
+
   return {
     props: {
-      contests,
+      dehydratedState: dehydrate(queryClient),
     },
   };
 };
 
-const HackathonPage: NextPage<{ contests: IContests }> = ({
-  contests,
-}: {
-  contests: IContests;
-}) => {
-  // FIXME: 삭제 예정
-  if (process.env.NODE_ENV === "development") console.log(contests);
+const HackathonPage: NextPage = () => {
   return (
     <>
       <Recommendation />


### PR DESCRIPTION
## 메인 변경 사항
- 해커톤 목록 페이지 차곡 추천 api 연동
- 해커톤 목록(인기순, 최신순, 마감순, 댓글많은순) api 연동
- react-query & next ssr 연동

### 기타 변경 사항
- IDE에서 직관적인 확인을 위해 해커톤 타입 `interface` -> `type alias`로 전환
- msw `/hackathons`에 대한 요청 모킹 제거
- d-day 계산 유틸 함수 작성
- contest korea에서 로드한 이미지를 next/image로 최적화하기 위한 next config 도메인 추가