### PR TITLE
:bug: Fix: 로그인 모달을 닫으면 query string이 지워지는 문제 수정

### DIFF
--- a/src/components/signup/index.tsx
+++ b/src/components/signup/index.tsx
@@ -54,6 +54,13 @@ const SignupModal: FC<ISignupProps> = ({
     closeModal();
   };
 
+  useEffect(() => {
+    if (clearParams && searchParams.get("code")) {
+      router.replace(`${window.location.pathname}`);
+      setClearParams(false);
+    }
+  }, [clearParams, router, searchParams]);
+
   const { mutate: signInMutate } = useChagokSignIn({
     onSuccess: (data?: TSignInResponse) => {
       if (data?.isSignUp && data?.jwtToken) {
@@ -115,13 +122,6 @@ const SignupModal: FC<ISignupProps> = ({
   const emptySkills = () => {
     setSkills([]);
   };
-
-  useEffect(() => {
-    if (clearParams) {
-      router.replace(`${window.location.pathname}`);
-      setClearParams(false);
-    }
-  }, [clearParams, router]);
 
   useEffect(() => {
     const authCode = searchParams.get("code");


### PR DESCRIPTION
카카오 로그인 과정중 authorization code가 생겼을 때만 query string이 초기화되도록 수정